### PR TITLE
added requirements.txt and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,11 @@ Concierge currently contains tests and/or exploits for the following vendors:
 * Mercury Security OEM (Mercury, Lenel, Honeywell, and others)  
 * Generic/Vendor Neutral  
   
-## Installation  
-Still working on putting together a full install script and such, but it's python, it's pretty straight forward. The following is a list of all python libraries used by the scripts.  
-  
+## Installation
+Concierge currently uses Python 2.7. You can install the necessary modules using the included requirements.txt:
 ```
-easysnmp
-os
-time
-SimpleHTTPServer
-SocketServer
-argparse
-binascii
-netaddr
-python-nmap
-pyshark
-re
-socket
-sys
-threading
-urllib2
-```  
+pip install -r requirements.txt
+```
   
 ## Usage  
 Usage for each script can be found it's associated directory's README.md file. At least until I get a wiki going.  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+easysnmp==0.2.5
+futures==3.2.0
+Logbook==1.3.0
+lxml==4.2.1
+netaddr==0.7.19
+py==1.5.3
+pyshark==0.3.7.11
+python-nmap==0.6.1
+trollius==1.0.4


### PR DESCRIPTION
People can now do a ```pip install -r requirements``` to get the needed modules. The builtin modules were not included since they don't get pulled in from Pypi.

The version numbers can be removed if you are confident future versions of their modules won't break your functionality, but that's your call :D